### PR TITLE
Get key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+KeyStore/
+*.key

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # IPNSGoServer
 
-## This repo is currently still under development and does not work as intended.
-
 # About 
 
 This project is meant to bring dynamic, decentralized data to any project. It started in the Web3 Jam 2021 hackathon, out of the founders need for customizeable decentralized content. While searching for resources, there were more creators asking the same question. "What is the best way to have elements in a NFT's metadata change based on certain events using IPFS?". This api is meant for devs looking to create dapps or services that give their users customizeable content in a web3 way. 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/ipfs/go-ds-flatfs v0.5.1
 	github.com/ipfs/go-ipfs v0.11.0
 	github.com/ipfs/go-ipfs-api v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 h1:BBso6MBKW
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5/go.mod h1:JpoxHjuQauoxiFMl1ie8Xc/7TfLuMZ5eOCONd1sUBHg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
@@ -323,7 +325,10 @@ github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f h1:KMlcu9X58lhTA/KrfX8Bi1LQSO4pzoVjTiL3h4Jk+Zk=
 github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/misc/References/ReferenceCode.go
+++ b/misc/References/ReferenceCode.go
@@ -1,5 +1,7 @@
 import (
 	"io/ioutil"
+	"net/http"
+	"encoding/json"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	keystore "github.com/ipfs/go-ipfs-keystore"
@@ -117,4 +119,24 @@ func exportKey(keyName string) error {
 		return err
 	}
 	return nil
+}
+
+func badRequest(wrt http.ResponseWriter, req *http.Request) {
+	keys, ok := req.URL.Query()["keyName"]
+
+	// Query()["keyName"] will return an array of items,
+	// we only want the single item.
+	keyName := keys[0]
+	if !ok || len(keys[0]) < 1 {
+        log.Println("Url Param 'keyName' is missing")
+		wrt.WriteHeader(http.StatusBadRequest)
+		wrt.Header().Set("Content-Type", "application/octet-stream")
+		resp := make(map[string]string)
+		resp["message"] = "Status Bad Request"
+		jsonResp, err:= json.Marshal(resp)
+		if err != nil {
+			log.Fatalf("Error in JSON marshal. Err: %s", err)
+		}
+		wrt.Write(jsonResp)
+    } 
 }

--- a/requests.sh
+++ b/requests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash 
+
+curl http://localhost:8082/postKey?CID=QmSVjCYjy4jYZynyC2i5GeFgjhq1bLCK2vrkRz5ffnssqo -F "file=@temp.key" -vvv

--- a/server.go
+++ b/server.go
@@ -10,15 +10,18 @@ package main
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
     "time"
 	"context"
-	// "io"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	// "bytes"
 	// "io/ioutil"
 
-    // "github.com/gorilla/mux"
+    "github.com/gorilla/mux"
 	
 	shell "github.com/ipfs/go-ipfs-api"
     pb "github.com/ipfs/go-ipns/pb"
@@ -80,17 +83,6 @@ func createEntry(ipfsPath string, sk ic.PrivKey) (*pb.IpnsEntry, error) {
 	return entry, nil
 }
 
-// Delete key from local node keystore
-// Correct
-func deleteKey(keyName string) error {
-	sh := shell.NewShell(localhost)
-	_, err := sh.KeyRm(context.Background(), keyName)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // Custom publishing function returns the response object and error
 // Correct?
 func Publish(contentHash string, key string) (*PublishResponse, error) {
@@ -122,6 +114,30 @@ func publishToIPNS(ipfsPath string, KeyName string) {
 	fmt.Printf("\nresponse Name: %s\nresponse Value: %s\n", pubResp.Name, pubResp.Value)
 }
 
+// Delete key from local node keystore
+// Correct
+func deleteKey(keyName string) error {
+	sh := shell.NewShell(localhost)
+	_, err := sh.KeyRm(context.Background(), keyName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// This function deletes the exported key from current (default) dir
+func localDelete(keyName string) error {
+	args := []string{keyName+".key"}
+	cmd := exec.Command("rm", args...)
+	stdout, err := cmd.Output()
+	if err != nil {
+		fmt.Println("Error in local delete: ", err.Error())
+		return err
+	}
+	fmt.Println(string(stdout))
+	return nil
+}
+
 // This function takes a key name and searches for it in local node Keystore.
 // returns nil if sucessfull & stores key as file in current dir.
 func exportKey(keyName string) error {
@@ -129,7 +145,7 @@ func exportKey(keyName string) error {
 	cmd := exec.Command("ipfs", args...)
 	stdout, err := cmd.Output()
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println("Error in export: ", err.Error())
 		return err
 	}
 	fmt.Println(string(stdout))
@@ -143,11 +159,44 @@ func importKey(keyName string, fileName string) error{
 	cmd := exec.Command("ipfs", args...)
 	stdout, err := cmd.Output()
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println("Error in import exec: ", err)
 		return err
 	}
 	fmt.Println(string(stdout))
 	return nil
+}
+
+// This function generates a key using local node and returns it
+// correct
+func genKey(keyName string) (*shell.Key, error) {
+	sh := shell.NewShell(localhost) //grab local node
+
+	key, err := sh.KeyGen(context.Background(), keyName) //generate temp key to local node
+
+	return key, err	
+}
+
+// This function parses the parameters in URL to grab the CID.
+func GetCID(wrt http.ResponseWriter, req *http.Request) (string, error) {
+	CIDs, ok := req.URL.Query()["CID"]
+
+	// Query()["keyName"] will return an array of items,
+	// we only want the single item.
+	if !ok || len(CIDs[0]) < 1 {
+		log.Println("Url Param 'CID' is missing")
+		wrt.WriteHeader(http.StatusBadRequest)
+		wrt.Header().Set("Content-Type", "application/octet-stream")
+		resp := make(map[string]string)
+		resp["message"] = "Status Bad Request - Missing CID"
+		jsonResp, err:= json.Marshal(resp)
+		if err != nil {
+			log.Fatalf("Error in JSON marshal. Err: %s", err)
+			return "", err
+		}
+		wrt.Write(jsonResp)
+	} 
+	return CIDs[0], nil
+		
 }
 
 // Generate keys and embed records. Meant to test how keys are needed to be passed.
@@ -180,22 +229,123 @@ func testFunctions(ipfsPath string) {
 	fmt.Printf("functions individually work.\n\n")
 }
 
+// This function generates a key, exports it to "<keyName>.key" file in current dir, then delete from local keystore.
+// returns newly generated key file to user
+func GetKey(w http.ResponseWriter, req *http.Request) {
+	keyName := "temp" // user input from API or self-generated non-clashing name
+	w.Header().Set("Content-Disposition", "attachment; filename="+string(keyName))
+	w.Header().Set("Content-Type", "application/octet-stream")
+	fmt.Println("Generating key...")
+	key, err := genKey(keyName)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		resp := make(map[string]string)
+		resp["message"] = "Status Bad Request"
+		jsonResp, err:= json.Marshal(resp)
+		if err != nil {
+			log.Fatalf("Error in JSON marshal. Err: %s", err)
+		}
+		w.Write(jsonResp)
+	}
+
+	fmt.Println("Exporting key...")
+	err = exportKey(keyName)
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	fmt.Println("Deleting key...")
+	err = deleteKey(key.Name) // delete temp key
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	log.Println("Url Param 'keyName' is: " + string(keyName))
+	http.ServeFile(w, req, string(keyName) + ".key") // serve key to user to download
+
+	fmt.Println("Deleting exported file...")
+	err = localDelete(keyName)
+	if err != nil {
+		panic(err)
+		return
+	}
+	return
+}
+
+
+// This function take a file and path and publish to ipfs
+// Returns ACK & IPNS path
+func PostKey(w http.ResponseWriter, r *http.Request) {
+	var FileName string
+	fmt.Println("PostKey...")
+	r.ParseMultipartForm(32 << 10) // limit max input length
+	// var buf bytes.Buffer
+	// in your case file would be fileupload
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	FileName = header.Filename
+	nameArr := strings.Split(header.Filename, ".")
+	name := nameArr[0]
+	// fmt.Printf("File: %s\nFile name: %s\nFile extension: %s\n", header.Filename, name[0], name[1])
+	// Copy the file data to my buffer
+	f, err := os.OpenFile("KeyStore/"+FileName, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		fmt.Println("Error in OpenFile: ", err)
+		return
+	}
+	io.Copy(f, file)
+	
+	CID, err := GetCID(w,r)
+	if err != nil {
+		fmt.Println("Error in GetCID: ", err)
+		return
+	}
+
+	err = importKey(name, "KeyStore/"+FileName)
+	if err != nil {
+		fmt.Println("Error in importKey: ", err)
+		return
+	}
+
+
+
+	publishToIPNS(ipfsURI + CID, FileName)
+	// do something with the contents...
+	// I normally have a struct defined and unmarshal into a struct, but this will
+	// work as an example
+	// contents := buf.String()
+	// fmt.Println(contents)
+	// I reset the buffer in case I want to use it again
+	// reduces memory allocations in more intense projects
+	// buf.Reset()
+	// do something else
+	// etc write header
+	return
+}
+
+
 
 func main() {
-	ipfsPath, err := addToIPFS(file)
-	if err != nil{
-		log.Panic(err)
-	}
+	// ipfsPath, err := addToIPFS(file)
+	// if err != nil{
+	// 	log.Panic(err)
+	// }
 	// Used to test if keys need to be passed as objects or ints?
-	testFunctions(ipfsPath)
+	// testFunctions(ipfsPath)
 
 
 	// handles api/website routes.
-	// router := mux.NewRouter().StrictSlash(true)
-    // router.HandleFunc("/", index)
-	// router.HandleFunc("/getKey", getKey).Methods("GET")
-	// router.HandleFunc("/postKey", postKey).Methods("POST")
+	router := mux.NewRouter().StrictSlash(true)
+    router.HandleFunc("/", index)
+	router.HandleFunc("/getKey", GetKey).Methods("GET")
+	router.HandleFunc("/postKey", PostKey).Methods("POST")
 
-	// fmt.Printf("Starting server at port 8082\n")
-	// log.Fatal(http.ListenAndServe(":8082", router))
+	fmt.Printf("Starting server at port 8082\n")
+	log.Fatal(http.ListenAndServe(":8082", router))
 }

--- a/server.go
+++ b/server.go
@@ -238,15 +238,8 @@ func GetKey(w http.ResponseWriter, req *http.Request) {
 	fmt.Println("Generating key...")
 	key, err := genKey(keyName)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Header().Set("Content-Type", "application/octet-stream")
-		resp := make(map[string]string)
-		resp["message"] = "Status Bad Request"
-		jsonResp, err:= json.Marshal(resp)
-		if err != nil {
-			log.Fatalf("Error in JSON marshal. Err: %s", err)
-		}
-		w.Write(jsonResp)
+		panic(err)
+		return
 	}
 
 	fmt.Println("Exporting key...")


### PR DESCRIPTION
Multiple Features were added:

- Get() endpoint
   - generate key to local node keystore
   - export key to default local dir
   - delete key from local node keystore
   - return .key file to client to download
   - delete key from local dir

- Put() endpoint
   - accept & grab uploaded .key file from client
   - accept & grab CID from client (TODO: accept multiple files, to upload to IPFS for user)
   - import .key file to local node keystore
   - use key to publish content to IPFS signed with user's key
   - TODO: delete key from local node keystore