### PR TITLE
Follow records

### DIFF
--- a/Hello
+++ b/Hello
@@ -1,1 +1,2 @@
 Hello World from the 6 god
+teir 2

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ As previously mentioned, IPNS records need to be republished after a certain per
 
 # API 
 
-There are seven endpoints currently:
+There are nine endpoints currently:
 
 getKey() - This will generate and return a private/public key pair in .key format. *The private keys are used to create, update, and republish IPNS records.*
 
 postKey(<key_name>.key) - This will import the private key to node.
 
-deleteKey(<key_name> string) - This will delete private key from node.
+deleteKey(<keyName> string) - This will delete private key from node.
 
 getRecord(<IPNS_key> string) - This will resolve what IPNS record points to and return IPFS Path. *Does not do continuous resolution aka IPNS Following*
 
@@ -36,7 +36,9 @@ postRecord(<IPFS_CID> string, <key_name>.key) - This will publish a brand new IP
 
 putRecord(<IPNS_key> string, <key_name>.key) - This will resolve IPNS record and returns IPFS path. Saves private key to allow for republishing.
 
-followRecord(<IPNS_key> string) - This will add IPNS record to queue to allow for continuous resolution aka IPNS Following. *Will not resolve record immediately use GetRecord() to resolve upon request.*
+startFollowing(<IPNS_key> string) - This will add IPNS record to queue to allow for continuous resolution aka IPNS Following. Returns status 200 & IPNS_key. *Will not resolve record immediately use GetRecord() to resolve upon request.*
+
+stopFollowing(<IPNS_key> string) - This will remove a key from the queue. Returns status 200 & IPNS_key.
 
 add(file) - This will add content to IPFS. Will return CID.
 
@@ -44,7 +46,6 @@ add(file) - This will add content to IPFS. Will return CID.
 
 add(dir) - This will add directory to IPFS. Will return CID.
 
-stopFollowing(<IPNS_key> string) - This will remove a key from the queue.
 
 
 # To Run

--- a/Uploads/Hello
+++ b/Uploads/Hello
@@ -1,1 +1,2 @@
 Hello World from the 6 god
+teir 2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/gammazero/deque v0.1.0
+	github.com/gammazero/deque v0.1.1
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/ipfs/go-datastore v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWp
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/gammazero/deque v0.1.0 h1:f9LnNmq66VDeuAlSAapemq/U7hJ2jpIWa4c09q8Dlik=
 github.com/gammazero/deque v0.1.0/go.mod h1:KQw7vFau1hHuM8xmI9RbgKFbAsQFWmBpqQ2KenFLk6M=
+github.com/gammazero/deque v0.1.1 h1:xRVkDuSvDmFuMGf3IquHuRc2jlL0+v/WpFCWaauzwbE=
+github.com/gammazero/deque v0.1.1/go.mod h1:KQw7vFau1hHuM8xmI9RbgKFbAsQFWmBpqQ2KenFLk6M=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=

--- a/ipfs.go
+++ b/ipfs.go
@@ -8,8 +8,6 @@ import (
 	shell "github.com/ipfs/go-ipfs-api"
 )
 
-// var ipfsURI = "/ipfs/"
-
 type PublishResponse struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`

--- a/records.go
+++ b/records.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	// "errors"
+	
 )
+
 // This function will accept a ipns key and resolve it
 // returns the ipfs path it resolved.
 func GetRecord(w http.ResponseWriter, r *http.Request) {
@@ -115,30 +118,72 @@ func PutRecord(w http.ResponseWriter, r *http.Request) {
 	writeJSONSuccess(w, "Success - PutRecord", ipfsPath)
 }
 
-// This function will return the first element of the queue and add it to the back
-func FollowRecord(w http.ResponseWriter, r *http.Request) {
-	ipnsKey := follow()
-	if ipnsKey == "" {
-		writeJSONError(w, "Queue is empty", nil)
+// This function will take a ipnskey and add it to the queue
+// Returns 200 response
+func StartFollowing(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("Getting IPNS Key...")
+	key, ok := GetParam(r, "ipnskey") // grab key from query parameter
+	if ok != true {
+		writeJSONError(w, "Error with getting key: "+key, nil)
 		return
 	}
-	writeJSONSuccess(w, "Success - PopFront", ipnsKey)
+	
+	q.PushBack(key)
+	
+	writeJSONSuccess(w, "Success - Started following", key)
 }
 
-// Helper function so that we can call internally and externally
-// returns the key at front of queue
-func follow() string {
-	defer func() { // <- executes only if there is a panic when using the queue
-		if (recover() != nil){
-			fmt.Sprintf("Error with queue operations %s")
-			return
-		}
-	}()
+func StopFollowing(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("Getting IPNS Key...")
+	key, ok := GetParam(r, "ipnskey") // grab key from query parameter
+	if ok != true {
+		writeJSONError(w, "Error with getting key: "+key, nil)
+		return
+	}
+	
+	err := stopFollow(key)
+	if err != nil {
+		writeJSONError(w, "Error in StopFollow", err)
+		return
+	}
+	writeJSONSuccess(w, "Success - Stopped Following", key)
+}
 
-	ipnsKeyInt := q.PopFront()
-	ipnsKey := fmt.Sprintf("%s", ipnsKeyInt) // Used to convert interface to string
-	// fmt.Printf("Success - top key is: %s\n", ipnsKey)
-	q.PushBack(ipnsKey)
+// This function will delete a key from the queue
+// return success or error
+func stopFollow(ipnsKey string) error {
+	if q.Len() < 1 {
+		fmt.Sprintf("Queue is empty")
+		return fmt.Errorf("Queue is empty")
+	}
+
+	var ipnsKeyInt interface{} = ipnsKey
+	index := q.Index(func(item interface{}) bool {
+		return item == ipnsKeyInt
+	})
+	fmt.Printf("Key at index: %d", index)
+	// if q.Index() returns -1 aka value not found
+	if index < 0 {
+		fmt.Printf("Key %s not in queue", ipnsKey)
+		return fmt.Errorf("Key %s not in queue", ipnsKey)
+	}
+	q.Remove(index)
+	return nil
+}
+
+// This function resolves and rotates keys in queue
+// returns the key at front of queue
+func follow() (string) {
+	// if q is empty
+	if q.Len() < 1 {
+		fmt.Sprintf("Queue is empty")
+		return ""
+	}
+
+	ipnsKey := fmt.Sprintf("%s", q.Front())// Used to convert interface to string
+
+	q.Rotate(1) //moves front elem to the back
+
 	ipfsPath, err := resolve(ipnsKey)
 	if err != nil {
 		fmt.Printf("Error in resolve %s", err)

--- a/records.go
+++ b/records.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+// This function will accept a ipns key and resolve it
+// returns the ipfs path it resolved.
+func GetRecord(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("Getting IPNS Key...")
+	ipnsKey, ok := GetParam(r, "ipnskey") // grab ipnskey from query parameter
+	if ok != true {
+		writeJSONError(w, "Error with getting ipnskey", nil)
+		return
+	}
+
+	fmt.Println("Resolving IPNS Record...")
+	ipfsPath, err := resolve(ipnsKey) // download content and return ipfs path
+	if err != nil {
+		writeJSONError(w, "Error in resolve", err)
+		return
+	}
+
+	q.PushBack(ipnsKey)
+
+	writeJSONSuccess(w, "Success - GetRecord", ipfsPath)
+}
+
+// This function takes a CID and file.key and publishes brand new IPNS records to IPFS
+// IPFS Node handles republishing automatically in the background as long as it is up and running
+// Returns ACK & IPNS path
+func PostRecord(w http.ResponseWriter, r *http.Request) {
+	const dir = "KeyStore"
+	
+	fmt.Println("Getting CID...")
+	CID, ok := GetParam(r, "CID") // grab CID from query parameter
+	if ok != true {
+		writeJSONError(w, "Error with getting CID: "+CID, nil)
+		return
+	}
+
+	FileName, err := saveFile(r, dir, 32 << 10) // grab uploaded .key file
+	if err != nil {
+		writeJSONError(w, "Error in saveFile", err)
+		return
+	}
+	name := strings.Split(FileName, ".")[0]
+
+	fmt.Println("Importing Key...")
+	err = importKey(name, dir+"/"+FileName) //import key to local node keystore
+	if err != nil {
+		writeJSONError(w, "Error in importKey", err)
+		return
+	}
+
+	fmt.Println("Publishing to IPNS...")
+	pubResp, err := publishToIPNS(ipfsURI + CID, name) //publish IPNS record to IPFS
+	if err != nil {
+		writeJSONError(w, "Error in publishToIPNS", err)
+		return
+	}
+
+	fmt.Println("Deleting exported key...")
+	err = diskDelete(dir+"/"+FileName) // delete key from disk
+	if err != nil {
+		writeJSONError(w, "Error in diskDelete", err)
+		return
+	}
+
+	fmt.Printf("\nresponse Name: %s\nresponse Value: %s\n", pubResp.Name, pubResp.Value)
+	writeJSONSuccess(w, "Success - PostKey", ipnsURI+pubResp.Name)
+}
+
+// This function takes an IPNS Key and file.key and resolves IPNS record
+// IPFS Node handles republishing automatically in the background as long as it is up and running
+// Returns ACK & resolved content
+func PutRecord(w http.ResponseWriter, r *http.Request) {
+	const dir = "KeyStore"
+	
+	fmt.Println("Getting IPNS Key...")
+	key, ok := GetParam(r, "ipnskey") // grab key from query parameter
+	if ok != true {
+		writeJSONError(w, "Error with getting key: "+key, nil)
+		return
+	}
+
+	FileName, err := saveFile(r, dir, 32 << 10) // grab uploaded .key file
+	if err != nil {
+		writeJSONError(w, "Error in saveFile", err)
+		return
+	}
+	name := strings.Split(FileName, ".")[0]
+
+	fmt.Println("Importing Key...")
+	err = importKey(name, dir+"/"+FileName) //import key to local node keystore
+	if err != nil {
+		writeJSONError(w, "Error in importKey", err)
+		return
+	}
+
+	fmt.Println("Resolving IPNS Record...")
+	ipfsPath, err := resolve(key) // download content and return ipfs path
+	if err != nil {
+		writeJSONError(w, "Error in resolve", err)
+		return
+	}
+
+	fmt.Println("Deleting saved key from disk...")
+	err = diskDelete(dir+"/"+FileName) // delete key from disk
+	if err != nil {
+		writeJSONError(w, "Error in deleteKey", err)
+		return
+	}
+	writeJSONSuccess(w, "Success - PutRecord", ipfsPath)
+}
+
+// This function will return the first element of the queue and add it to the back
+func FollowRecord(w http.ResponseWriter, r *http.Request) {
+	ipnsKey := follow()
+	if ipnsKey == "" {
+		writeJSONError(w, "Queue is empty", nil)
+		return
+	}
+	writeJSONSuccess(w, "Success - PopFront", ipnsKey)
+}
+
+// Helper function so that we can call internally and externally
+// returns the key at front of queue
+func follow() string {
+	defer func() { // <- executes only if there is a panic when using the queue
+		if (recover() != nil){
+			fmt.Sprintf("Error with queue operations %s")
+			return
+		}
+	}()
+
+	ipnsKeyInt := q.PopFront()
+	ipnsKey := fmt.Sprintf("%s", ipnsKeyInt) // Used to convert interface to string
+	// fmt.Printf("Success - top key is: %s\n", ipnsKey)
+	q.PushBack(ipnsKey)
+	ipfsPath, err := resolve(ipnsKey)
+	if err != nil {
+		fmt.Printf("Error in resolve %s", err)
+		return ""
+	}
+	return ipfsPath
+}

--- a/requests.sh
+++ b/requests.sh
@@ -1,9 +1,30 @@
 #!/bin/bash 
+PORT=":8082"
+LOCALHOST="localhost"
+host="$LOCALHOST$PORT"
+echo $host
 
-# curl --request GET http://localhost:8082/getKey 
+# curl --request POST http://$host/addFile -F "file=@Hello" -v
 
-# curl http://localhost:8082/postKey?CID=QmSVjCYjy4jYZynyC2i5GeFgjhq1bLCK2vrkRz5ffnssqo -F "file=@temp.key" -vvv
+# curl --request GET http://$host/getKey
 
-# curl http://localhost:8082/addFile -F "file=@Hello" -v
+# curl --request POST http://$host/postKey? -F "file=@temp.key" -v
 
-curl --request GET http://localhost:8082/followRecord
+# curl --request DELETE http://$host/deleteKey?keyName=temp
+
+# curl --request GET http://$host/getRecord?ipnskey=k51qzi5uqu5dm876hw4kh2mn58rnajofhoohohymt9bui38q6ogsa0rrct6fnh
+
+# curl --request POST http://$host/startFollowing?ipnskey=k51qzi5uqu5dm876hw4kh2mn58rnajofhoohohymt9bui38q6ogsa0rrct6fnh
+
+curl --request DELETE http://$host/stopFollowing?ipnskey=k51qzi5uqu5dm876hw4kh2mn58rnajofhoohohymt9bui38q6ogsa0rrct6fnh
+
+# curl --request POST http://$host/postRecord?CID=QmSVjCYjy4jYZynyC2i5GeFgjhq1bLCK2vrkRz5ffnssqo -F "file=@temp.key" -v
+
+# for ease of use, just using local commands
+# ipfspath=$(ipfs add Hello)
+# ipnskey=$(ipfs key gen temp1)
+# ipfs key export temp1
+# ipfs publish --key=temp1 "$ipfspath"
+# ipfs key rm temp1
+
+# curl --request PUT http://$host/putRecord?ipnskey="$ipnskey" -F "file=@temp1.key" -v

--- a/server.go
+++ b/server.go
@@ -6,310 +6,23 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"context"
-	"encoding/json"
-	"io"
 	"net/http"
-	"strings"
 
     "github.com/gorilla/mux"
 	"github.com/gammazero/deque"
 	"github.com/robfig/cron"
-	shell "github.com/ipfs/go-ipfs-api"
 )
 
 const FILE = "Hello"
 const localhost = "localhost:5001"
 
 const ipfsURI = "/ipfs/"
-const ipnsURI = "/ipns/"
 
 var q deque.Deque
-
 
 func index(w http.ResponseWriter, r *http.Request){
     fmt.Fprintf(w, "Welcome to the HomePage!")
     fmt.Println("Endpoint Hit: HomePage")
-}
-
-
-
-// Generate keys and embed records. Meant to test how keys are needed to be passed.
-func testFunctions(ipfsPath string) {
-	const KeyName = "temp"
-	sh := shell.NewShell(localhost)
-
-	key, err := sh.KeyGen(context.Background(), KeyName) //generate temp key to local node
-	if err != nil {
-		panic(err)
-	}
-
-	// publishToIPNS(ipfsPath, key.Name) // publish ipfsPath to ipfs under temp key
-	fmt.Println("Exporting key...")
-	err = exportKey(KeyName)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println("Deleting key...")
-	err = deleteKey(key.Name) // delete temp key
-	if err != nil {
-		panic(err)
-	}
-
-	err = importKey(key.Name, key.Name + ".key")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("functions individually work.\n\n")
-}
-
-// This function grabs the specified parameter value out the URL
-func GetParam(r *http.Request, parameter string) (string, bool) {
-	params, ok := r.URL.Query()[parameter]
-	// Query()[parameter] will return an array of items,
-	// we only want the single item.
-	if !ok || len(params[0]) < 1 {
-		fmt.Println("Error: Missing " + parameter)
-		return "Missing "+parameter+" parameter", !ok
-	} 
-	return params[0], ok
-}
-
-// This function generates a key, exports it to "<keyName>.key" file in current dir, then delete from local keystore.
-// returns newly generated key file to user
-func GetKey(w http.ResponseWriter, r *http.Request) {
-	keyName := "temp" // user input from API or self-generated non-clashing name
-	fmt.Println("Generating key...")
-	key, err := genKey(keyName)
-	if err != nil {
-		writeJSONError(w, "Error in genKey", err)
-		return
-	}
-	
-	fmt.Println("Exporting key...")
-	err = exportKey(keyName)
-	if err != nil {
-		writeJSONError(w, "Error in keyName", err)
-		return
-	}
-	
-	fmt.Println("Deleting key...")
-	err = deleteKey(key.Name) // delete temp key from local node keystore
-	if err != nil {
-		writeJSONError(w, "Error in deleteKey", err)
-		return
-	}
-
-
-	// log.Println("Url Param 'keyName' is: " + string(keyName))
-	w.Header().Set("Content-Disposition", "attachment; filename="+string(keyName))
-	w.Header().Set("Content-Type", "application/octet-stream")
-	w.WriteHeader(http.StatusOK)
-	http.ServeFile(w, r, string(keyName) + ".key") // serve key to user to download
-
-
-	fmt.Println("Deleting exported key...")
-	err = diskDelete(keyName+".key") // delete key from disk
-	if err != nil {
-		panic(err)
-		return
-	}
-
-	// fmt.Println("Deleting exported key a second time...")
-	// err = diskDelete(keyName) // delete key from disk again to force error
-	// if err != nil {
-	// 	writeJSONError(w, "Error in deleteKey", err)
-	// 	return
-	// }
-}
-
-// This function will save a key to node, then delete the uploaded file from disk
-// Returns 200 & key name as confirmation
-func PostKey(w http.ResponseWriter, r *http.Request) {
-	const dir = "KeyStore"
-	FileName, err := saveFile(r, dir, 32 << 10) // grab uploaded .key file
-	if err != nil {
-		writeJSONError(w, "Error in saveFile", err)
-		return
-	}
-	name := strings.Split(FileName, ".")[0]
-
-	fmt.Println("Importing Key...")
-	err = importKey(name, dir+"/"+FileName) //import key to local node keystore
-	if err != nil {
-		writeJSONError(w, "Error in importKey", err)
-		return
-	}
-
-	fmt.Println("Deleting saved key from disk...")
-	err = diskDelete(dir+"/"+FileName) // delete key from disk
-	if err != nil {
-		writeJSONError(w, "Error in deleteKey", err)
-		return
-	}
-	writeJSONSuccess(w, "Success - Saved key", name)
-}
-
-// This function will delete a key from the local node keystore
-func DeleteKey(w http.ResponseWriter, r *http.Request) {
-	keyName, ok := GetParam(r, "keyName")
-	if ok != true {
-		writeJSONError(w, keyName, nil)
-		return
-	}
-
-	fmt.Println("Deleting key...")
-	err := deleteKey(keyName) // delete temp key from local node keystore
-	if err != nil {
-		writeJSONError(w, "Error in deleteKey", err)
-		return
-	}
-	writeJSONSuccess(w, "Success - Deleted key", keyName)
-}
-
-// This function will accept a ipns key and resolve it
-// returns the ipfs path it resolved.
-func GetRecord(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("Getting IPNS Key...")
-	ipnsKey, ok := GetParam(r, "ipnskey") // grab ipnskey from query parameter
-	if ok != true {
-		writeJSONError(w, "Error with getting ipnskey", nil)
-		return
-	}
-
-	fmt.Println("Resolving IPNS Record...")
-	ipfsPath, err := resolve(ipnsKey) // download content and return ipfs path
-	if err != nil {
-		writeJSONError(w, "Error in resolve", err)
-		return
-	}
-
-	q.PushBack(ipnsKey)
-
-	writeJSONSuccess(w, "Success - GetRecord", ipfsPath)
-}
-
-// This function takes a CID and file.key and publishes brand new IPNS records to IPFS
-// IPFS Node handles republishing automatically in the background as long as it is up and running
-// Returns ACK & IPNS path
-func PostRecord(w http.ResponseWriter, r *http.Request) {
-	const dir = "KeyStore"
-	
-	fmt.Println("Getting CID...")
-	CID, ok := GetParam(r, "CID") // grab CID from query parameter
-	if ok != true {
-		writeJSONError(w, "Error with getting CID: "+CID, nil)
-		return
-	}
-
-	FileName, err := saveFile(r, dir, 32 << 10) // grab uploaded .key file
-	if err != nil {
-		writeJSONError(w, "Error in saveFile", err)
-		return
-	}
-	name := strings.Split(FileName, ".")[0]
-
-	fmt.Println("Importing Key...")
-	err = importKey(name, dir+"/"+FileName) //import key to local node keystore
-	if err != nil {
-		writeJSONError(w, "Error in importKey", err)
-		return
-	}
-
-	fmt.Println("Publishing to IPNS...")
-	pubResp, err := publishToIPNS(ipfsURI + CID, name) //publish IPNS record to IPFS
-	if err != nil {
-		writeJSONError(w, "Error in publishToIPNS", err)
-		return
-	}
-
-	fmt.Println("Deleting exported key...")
-	err = diskDelete(dir+"/"+FileName) // delete key from disk
-	if err != nil {
-		writeJSONError(w, "Error in diskDelete", err)
-		return
-	}
-
-	fmt.Printf("\nresponse Name: %s\nresponse Value: %s\n", pubResp.Name, pubResp.Value)
-	writeJSONSuccess(w, "Success - PostKey", ipnsURI+pubResp.Name)
-}
-
-// This function takes an IPNS Key and file.key and resolves IPNS record
-// IPFS Node handles republishing automatically in the background as long as it is up and running
-// Returns ACK & resolved content
-func PutRecord(w http.ResponseWriter, r *http.Request) {
-	const dir = "KeyStore"
-	
-	fmt.Println("Getting IPNS Key...")
-	key, ok := GetParam(r, "ipnskey") // grab key from query parameter
-	if ok != true {
-		writeJSONError(w, "Error with getting key: "+key, nil)
-		return
-	}
-
-	FileName, err := saveFile(r, dir, 32 << 10) // grab uploaded .key file
-	if err != nil {
-		writeJSONError(w, "Error in saveFile", err)
-		return
-	}
-	name := strings.Split(FileName, ".")[0]
-
-	fmt.Println("Importing Key...")
-	err = importKey(name, dir+"/"+FileName) //import key to local node keystore
-	if err != nil {
-		writeJSONError(w, "Error in importKey", err)
-		return
-	}
-
-	fmt.Println("Resolving IPNS Record...")
-	ipfsPath, err := resolve(key) // download content and return ipfs path
-	if err != nil {
-		writeJSONError(w, "Error in resolve", err)
-		return
-	}
-
-	fmt.Println("Deleting saved key from disk...")
-	err = diskDelete(dir+"/"+FileName) // delete key from disk
-	if err != nil {
-		writeJSONError(w, "Error in deleteKey", err)
-		return
-	}
-	writeJSONSuccess(w, "Success - PutRecord", ipfsPath)
-}
-
-// This function will return the first element of the queue and add it to the back
-func FollowRecord(w http.ResponseWriter, r *http.Request) {
-	ipnsKey := follow(false)
-	if ipnsKey == "" {
-		writeJSONError(w, "Queue is empty", nil)
-		return
-	}
-	writeJSONSuccess(w, "Success - PopFront", ipnsKey)
-}
-
-// Helper function so that we can call internally and externally
-// returns the key at front of queue
-func follow(internal bool) string {
-	defer func() { // <- executes only if there is a panic when using the queue
-		if (recover() != nil){
-			fmt.Sprintf("Error with queue operations %s")
-			return
-		}
-	}()
-	ipnsKeyInt := q.PopFront()
-	ipnsKey := fmt.Sprintf("%s", ipnsKeyInt) // Used to convert interface to string
-	// fmt.Printf("Success - top key is: %s\n", ipnsKey)
-	q.PushBack(ipnsKey)
-	if internal {
-		ipfsPath, err := resolve(ipnsKey)
-		if err != nil {
-			fmt.Printf("Error in resolve %s", err)
-			return ""
-		}
-		return ipfsPath
-	}
-	return ipnsKey
 }
 
 // Grab uploaded file and add to ipfs
@@ -329,76 +42,17 @@ func AddFile(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, "Error in addToIPFS", err)
 		return
 	}
-	// TODO: Return this over http.response
 	fmt.Println("ipfs Path: ", ipfsPath)
 	writeJSONSuccess(w, "Success - addFile", ipfsPath)
 }
-
-// Grabs file with specified file size and save to specified dir
-// returns name of file
-func saveFile(r *http.Request, dir string, size int64) (string, error) {
-	var FileName string
-
-	fmt.Println("Saving file...")
-	r.ParseMultipartForm(size) // limit max input length
-	file, header, err := r.FormFile("file")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s ", err)
-		return "", err
-	}
-	defer file.Close()
-	FileName = header.Filename
-	
-	f, err := os.OpenFile(dir+"/"+FileName, os.O_WRONLY|os.O_CREATE, 0666)
-	if err != nil {
-		fmt.Println("Error in OpenFile: ", err)
-		return "", err
-	}
-	io.Copy(f, file)
-
-	return FileName, nil
-}
-
-// This function will set the appropiate headers for when there is an error.
-func writeJSONError(w http.ResponseWriter, msg string, err error) {
-	resp := make(map[string]interface{})
-	resp["message"] = msg
-	resp["error"] = err
-	jsonResp, err:= json.Marshal(resp)
-	if err != nil {
-		log.Fatalf("Error in JSON marshal. Err: %s", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusInternalServerError)
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(jsonResp)
-}
-
-// This function will set the appropiate headers for when there is an error.
-func writeJSONSuccess(w http.ResponseWriter, msg string, val string) {
-	resp := make(map[string]string)
-	resp["message"] = msg
-	resp["value"] = val
-	jsonResp, err:= json.Marshal(resp)
-	if err != nil {
-		log.Fatalf("Error in JSON marshal. Err: %s", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(jsonResp)
-}
-
 
 func main() {
 	// Used to test if keys need to be passed as objects or ints?
 	// testFunctions(ipfsPath)
 	c := cron.New()
 	c.AddFunc("@every 2m", func() {
-		ipfsPath := follow(true)
-		fmt.Printf(ipfsPath)	
+		ipfsPath := follow()
+		fmt.Printf("%s\n",ipfsPath)	
 	})
 	c.Start()
 	

--- a/server.go
+++ b/server.go
@@ -17,6 +17,7 @@ const FILE = "Hello"
 const localhost = "localhost:5001"
 
 const ipfsURI = "/ipfs/"
+const ipnsURI = "/ipns/"
 
 var q deque.Deque
 
@@ -74,7 +75,8 @@ func main() {
 	router.HandleFunc("/postRecord", PostRecord).Methods("POST")
 	router.HandleFunc("/putRecord", PutRecord).Methods("PUT")
 	router.HandleFunc("/getRecord", GetRecord).Methods("GET")
-	router.HandleFunc("/followRecord", FollowRecord).Methods("GET")
+	router.HandleFunc("/startFollowing", StartFollowing).Methods("POST")
+	router.HandleFunc("/stopFollowing", StopFollowing).Methods("Delete")
 	router.HandleFunc("/addFile", AddFile).Methods("POST")
 
 

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"context"
+	"encoding/json"
+	"io"
+
+
+	shell "github.com/ipfs/go-ipfs-api"
+
+)
+
+// This function will set the appropiate headers for when there is an error.
+func writeJSONError(w http.ResponseWriter, msg string, err error) {
+	resp := make(map[string]interface{})
+	resp["message"] = msg
+	resp["error"] = err
+	jsonResp, err:= json.Marshal(resp)
+	if err != nil {
+		log.Fatalf("Error in JSON marshal. Err: %s", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonResp)
+}
+
+// This function will set the appropiate headers for when there is an error.
+func writeJSONSuccess(w http.ResponseWriter, msg string, val string) {
+	resp := make(map[string]string)
+	resp["message"] = msg
+	resp["value"] = val
+	jsonResp, err:= json.Marshal(resp)
+	if err != nil {
+		log.Fatalf("Error in JSON marshal. Err: %s", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonResp)
+}
+
+// This function grabs the specified parameter value out the URL
+func GetParam(r *http.Request, parameter string) (string, bool) {
+	params, ok := r.URL.Query()[parameter]
+	// Query()[parameter] will return an array of items,
+	// we only want the single item.
+	if !ok || len(params[0]) < 1 {
+		fmt.Println("Error: Missing " + parameter)
+		return "Missing "+parameter+" parameter", !ok
+	} 
+	return params[0], ok
+}
+
+// Grabs file with specified file size and save to specified dir
+// returns name of file
+func saveFile(r *http.Request, dir string, size int64) (string, error) {
+	var FileName string
+
+	fmt.Println("Saving file...")
+	r.ParseMultipartForm(size) // limit max input length
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s ", err)
+		return "", err
+	}
+	defer file.Close()
+	FileName = header.Filename
+	
+	f, err := os.OpenFile(dir+"/"+FileName, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		fmt.Println("Error in OpenFile: ", err)
+		return "", err
+	}
+	io.Copy(f, file)
+
+	return FileName, nil
+}
+
+// Generate keys and embed records. Meant to test how keys are needed to be passed.
+func testFunctions(ipfsPath string) {
+	const KeyName = "temp"
+	sh := shell.NewShell(localhost)
+
+	key, err := sh.KeyGen(context.Background(), KeyName) //generate temp key to local node
+	if err != nil {
+		panic(err)
+	}
+
+	// publishToIPNS(ipfsPath, key.Name) // publish ipfsPath to ipfs under temp key
+	fmt.Println("Exporting key...")
+	err = exportKey(KeyName)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Deleting key...")
+	err = deleteKey(key.Name) // delete temp key
+	if err != nil {
+		panic(err)
+	}
+
+	err = importKey(key.Name, key.Name + ".key")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("functions individually work.\n\n")
+}


### PR DESCRIPTION
# Major upgrades:
- IPNS Following
   - startFollowing() - accepts a ipns key (k51foo...) and adds it to queue to be continuously resolved over time.
   - stopFollowing() V1 - accepts ipns key & deletes it from queue 
   - *future upgrades to stopFollowing will implement deletion after x resolutions &/or after x days.
   - test examples in bash for all endpoints
   - Refactored code
   
# Minor upgrades/changes:
- renamed endpoints
- README updates
- various logging bugs
- various small logic bugs